### PR TITLE
Rename the "token" option to "apiKey"

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ Create an `FpjsClient` instance before rendering or initializing your applicatio
 ```js
 import { FpjsClient } from '@fingerprintjs/fingerprintjs-pro-spa';
 
-// It can receive mulptiple parameters but the only required one is `loadOptions`, which contains the token
+// It can receive mulptiple parameters but the only required one is `loadOptions`, which contains the public API key
 const fpjsClient = new FpjsClient({
   loadOptions: {
-    token: "your-fpjs-public-api-key" // insert your public api key from the dashboard here
+    apiKey: "your-fpjs-public-api-key" // insert your public api key from the dashboard here
   }
 });
 ```
@@ -107,7 +107,7 @@ To use the session storage mode, no additional options need are required as this
 ```js
 const fpjsClient = new FpjsClient({
   loadOptions: {
-    token: "your-fpjs-public-api-key"
+    apiKey: "your-fpjs-public-api-key"
   },
   cacheLocation: 'localstorage'
 });
@@ -117,7 +117,7 @@ Or if you are using TypeScript:
 ```ts
 const fpjsClient = new FpjsClient({
   loadOptions: {
-    token: "your-fpjs-public-api-key"
+    apiKey: "your-fpjs-public-api-key"
   },
   cacheLocation: CacheLocation.LocalStorage
 });

--- a/__tests__/client.test.ts
+++ b/__tests__/client.test.ts
@@ -3,7 +3,7 @@ import { CacheLocation, FpjsClient } from '../src'
 import { CacheKey, getKeyWithPrefix, MAX_CACHE_LIFE } from '../src/cache'
 
 const getDefaultLoadOptions = () => ({
-  token: 'test_token',
+  apiKey: 'test_api_key',
 })
 
 describe(`SPA client`, () => {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 	},
 	"homepage": "https://github.com/fingerprintjs/fingerprintjs-pro-spa#readme",
 	"dependencies": {
-		"@fingerprintjs/fingerprintjs-pro": "^3.5.5",
+		"@fingerprintjs/fingerprintjs-pro": "^3.5.6",
 		"tslib": "^2.2.0"
 	},
 	"devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -308,18 +308,18 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@fingerprintjs/fingerprintjs-pro@^3.5.5":
-  version "3.5.5"
-  resolved "https://registry.yarnpkg.com/@fingerprintjs/fingerprintjs-pro/-/fingerprintjs-pro-3.5.5.tgz#010f8401dcff8c3bdcbe5732d2b1f97ca4996827"
-  integrity sha512-55LrMM9tDholII1zXNvuoem2htD/3OinXOaM2IX60s06kB73cKUIMwvs41GI5oiXuoTb8/jt2ZZ+H5fw7OfmvQ==
+"@fingerprintjs/fingerprintjs-pro@^3.5.6":
+  version "3.5.6"
+  resolved "https://registry.yarnpkg.com/@fingerprintjs/fingerprintjs-pro/-/fingerprintjs-pro-3.5.6.tgz#1a57cc940b61ca41693cbcad50593601d8a9185b"
+  integrity sha512-3Dtj5v1YIVpIKfdJDOqRG7b01D0XFZ1JbnQlCzkttZZkFbgA3Irukg9sZ2ed23opNnO82191x6WwWHDwEwNFyw==
   dependencies:
-    "@fingerprintjs/fingerprintjs" "3.3.1"
+    "@fingerprintjs/fingerprintjs" "3.3.3"
     tslib "^2.0.1"
 
-"@fingerprintjs/fingerprintjs@3.3.1":
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/@fingerprintjs/fingerprintjs/-/fingerprintjs-3.3.1.tgz#d080b0ea356b3ad14de4163afc3611beb5b5df20"
-  integrity sha512-rs9fCfINXeYO1XRTbZ/cXFSyRknyoZSwLNypO5Kf7C/o0g7mBpIDKVzJW3UsKEh+YybCS3wzaOK3z9PxtLiXaw==
+"@fingerprintjs/fingerprintjs@3.3.3":
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/@fingerprintjs/fingerprintjs/-/fingerprintjs-3.3.3.tgz#ead445032c92a79d5f585953019402ed223edc7d"
+  integrity sha512-HH6KqZnopF3NIXypYG4f2qxoSRmGCSzp81wJMfWjSTtvsX3cAg12RFJcm+a6Az3XadcZUrXKW3p5Dv0wyCUeuA==
   dependencies:
     tslib "^2.0.1"
 


### PR DESCRIPTION
This is not a breaking change because the `token` option still works