### PR TITLE
Bump JS Agent to 3.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "homepage": "https://github.com/fingerprintjs/fingerprintjs-pro-spa#readme",
   "dependencies": {
-    "@fingerprintjs/fingerprintjs-pro": "^3.7.1",
+    "@fingerprintjs/fingerprintjs-pro": "^3.8.0",
     "tslib": "^2.2.0"
   },
   "devDependencies": {

--- a/playground/yarn.lock
+++ b/playground/yarn.lock
@@ -8,15 +8,13 @@
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
 "@fingerprintjs/fingerprintjs-pro-spa@link:..":
-  version "0.5.0"
-  dependencies:
-    "@fingerprintjs/fingerprintjs-pro" "^3.7.1"
-    tslib "^2.2.0"
+  version "0.0.0"
+  uid ""
 
-"@fingerprintjs/fingerprintjs-pro@^3.7.1":
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/@fingerprintjs/fingerprintjs-pro/-/fingerprintjs-pro-3.7.1.tgz#ece7679d2bdb05bce9fc6c1a64f7aa8705f1b908"
-  integrity sha512-06t3lqFwq0fpt5MFfppoNfZgd/jhnfv15lklVtaGhqkKyNpB81kwCM9iIqku7dhaEUFXlGZg5VcoA8zjkC483A==
+"@fingerprintjs/fingerprintjs-pro@^3.8.0":
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/@fingerprintjs/fingerprintjs-pro/-/fingerprintjs-pro-3.8.0.tgz#586bef92c6bca912c03b38ab23437c12628d871c"
+  integrity sha512-ZSrpmkzIWk3UfArj/1QzTvFY30Q2sk2YbTaE9GvVvG5HZtHOEzv58FlClXpdmTl4Bkbzki6Fofc7t7R+P9ZDLg==
   dependencies:
     tslib "^2.0.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -475,10 +475,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@fingerprintjs/fingerprintjs-pro@^3.7.1":
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/@fingerprintjs/fingerprintjs-pro/-/fingerprintjs-pro-3.7.1.tgz#ece7679d2bdb05bce9fc6c1a64f7aa8705f1b908"
-  integrity sha512-06t3lqFwq0fpt5MFfppoNfZgd/jhnfv15lklVtaGhqkKyNpB81kwCM9iIqku7dhaEUFXlGZg5VcoA8zjkC483A==
+"@fingerprintjs/fingerprintjs-pro@^3.8.0":
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/@fingerprintjs/fingerprintjs-pro/-/fingerprintjs-pro-3.8.0.tgz#586bef92c6bca912c03b38ab23437c12628d871c"
+  integrity sha512-ZSrpmkzIWk3UfArj/1QzTvFY30Q2sk2YbTaE9GvVvG5HZtHOEzv58FlClXpdmTl4Bkbzki6Fofc7t7R+P9ZDLg==
   dependencies:
     tslib "^2.0.1"
 


### PR DESCRIPTION
Need to support fallbacks for `scriptUrlPattern`, `endpoint` and `tlsEndpoint`