### PR TITLE
Bugfix/agent error retry

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "scripts": {
     "prepare": "husky install",
     "build": "rimraf dist && rollup -c rollup.config.js",
+    "watch": "rimraf dist && rollup -c rollup.config.js -w",
     "lint": "eslint --ext .js,.ts --ignore-path .gitignore --max-warnings 0 .",
     "lint:fix": "yarn lint --fix",
     "test": "jest",
@@ -49,7 +50,7 @@
   },
   "homepage": "https://github.com/fingerprintjs/fingerprintjs-pro-spa#readme",
   "dependencies": {
-    "@fingerprintjs/fingerprintjs-pro": "^3.8.0",
+    "@fingerprintjs/fingerprintjs-pro": "^3.8.1",
     "tslib": "^2.2.0"
   },
   "devDependencies": {

--- a/playground/index.html
+++ b/playground/index.html
@@ -151,10 +151,11 @@
     <div class="buttons">
       <button disabled id="debugCopy">Copy Debug Data</button>
       <button disabled id="debugShare">Share Debug Data</button>
+      <button disabled id="getData">Get visitor data</button>
     </div>
     <div class="outputHolder">
       <section class="output">
-        <div class="heading">Getting the visitor identifier...</div>
+        <div class="heading">Visitor data will appear here.</div>
       </section>
     </div>
   </div>

--- a/playground/index.ts
+++ b/playground/index.ts
@@ -2,13 +2,13 @@ import { FpjsClient } from '@fingerprintjs/fingerprintjs-pro-spa'
 
 type Text = string | { html: string }
 
-async function getVisitorData() {
-  const fp = new FpjsClient({
-    loadOptions: {
-      apiKey: process.env.API_KEY as string,
-    },
-  })
+const fp = new FpjsClient({
+  loadOptions: {
+    apiKey: process.env.API_KEY as string,
+  },
+})
 
+async function getVisitorData() {
   await fp.init()
 
   return await fp.getVisitorData({
@@ -16,7 +16,7 @@ async function getVisitorData() {
   })
 }
 
-async function startPlayground() {
+async function getAndPrintData() {
   const output = document.querySelector('.output')
   if (!output) {
     throw new Error("The output element isn't found in the HTML code")
@@ -69,6 +69,18 @@ ${JSON.stringify(errorData, null, 2)}
 Time passed before the error: ${totalTime}ms
 User agent: \`${navigator.userAgent}\``)
     throw error
+  }
+}
+
+async function startPlayground() {
+  const getDataButton = document.querySelector('#getData')
+  if (getDataButton instanceof HTMLButtonElement) {
+    getDataButton.disabled = false
+    getDataButton.addEventListener('click', async (event) => {
+      event.preventDefault()
+
+      await getAndPrintData()
+    })
   }
 }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -84,10 +84,16 @@ export class FpjsClient {
    */
   public async init() {
     if (!this.agentPromise) {
-      this.agentPromise = FingerprintJS.load(this.loadOptions).then((agent) => {
-        this.agent = agent
-        return agent
-      })
+      this.agentPromise = FingerprintJS.load(this.loadOptions)
+        .then((agent) => {
+          this.agent = agent
+          return agent
+        })
+        .catch((error) => {
+          this.agentPromise = null
+
+          throw error
+        })
     }
 
     return this.agentPromise
@@ -105,9 +111,8 @@ export class FpjsClient {
     const key = cacheKey.toKey()
 
     if (!this.inFlightRequests.has(key)) {
-      const promise = this._identify(options, ignoreCache).then((visitorData) => {
+      const promise = this._identify(options, ignoreCache).finally(() => {
         this.inFlightRequests.delete(key)
-        return visitorData
       })
       this.inFlightRequests.set(key, promise)
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -475,10 +475,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@fingerprintjs/fingerprintjs-pro@^3.8.0":
-  version "3.8.0"
-  resolved "https://registry.yarnpkg.com/@fingerprintjs/fingerprintjs-pro/-/fingerprintjs-pro-3.8.0.tgz#586bef92c6bca912c03b38ab23437c12628d871c"
-  integrity sha512-ZSrpmkzIWk3UfArj/1QzTvFY30Q2sk2YbTaE9GvVvG5HZtHOEzv58FlClXpdmTl4Bkbzki6Fofc7t7R+P9ZDLg==
+"@fingerprintjs/fingerprintjs-pro@^3.8.1":
+  version "3.8.1"
+  resolved "https://registry.yarnpkg.com/@fingerprintjs/fingerprintjs-pro/-/fingerprintjs-pro-3.8.1.tgz#b972659f1d341b7054106a3f27c5ba028f8f2ea2"
+  integrity sha512-hIpShbh75po8j7AQQ2a/avI/X4KCe/wXR9B8+yeK9UQpnADBcNBuSCaaBIQDmDoHCxCsS/2hma91dgwt/u+6cA==
   dependencies:
     tslib "^2.0.1"
 


### PR DESCRIPTION
This PR fixes the issue in which if `FingerprintJS.load` would fail (in case of network errors for example) it wouldn't allow users to call it again once the network connection was restored. Full page reload was required in that case.

This bug was mentioned in https://github.com/fingerprintjs/fingerprintjs-pro-react/issues/70