### PR TITLE
feat: add option to disable cache time limit with warning

### DIFF
--- a/__tests__/client.test.ts
+++ b/__tests__/client.test.ts
@@ -25,6 +25,24 @@ describe(`SPA client`, () => {
     ).toThrow('Cache time cannot exceed 86400 seconds (24 hours)')
   })
 
+  it('should warn instead of throwing when cacheTime exceeds limit if __dangerouslyDisableCacheTimeLimitAndAcceptLowAccuracy is true', function () {
+    const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation()
+
+    const client = new FpjsClient({
+      loadOptions: getDefaultLoadOptions(),
+      cacheTimeInSeconds: MAX_CACHE_LIFE + 1000,
+      __dangerouslyDisableCacheTimeLimitAndAcceptLowAccuracy: true,
+    })
+
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      'WARNING: You are caching visitor data for longer than 24 hours. This will negatively affect identification accuracy. ' +
+        'To ensure high identification accuracy, we recommend not to cache visitors data for longer than 24 hours.'
+    )
+    expect(client).toBeInstanceOf(FpjsClient)
+
+    consoleWarnSpy.mockRestore()
+  })
+
   describe(`setup`, () => {
     const agentGetMock = jest.fn()
     const agentCollectMock = jest.fn()

--- a/src/client.ts
+++ b/src/client.ts
@@ -107,7 +107,14 @@ export class FpjsClient {
     }
 
     if (options?.cacheTimeInSeconds && options.cacheTimeInSeconds > MAX_CACHE_LIFE) {
-      throw new Error(`Cache time cannot exceed 86400 seconds (24 hours)`)
+      if (options.__dangerouslyDisableCacheTimeLimitAndAcceptLowAccuracy) {
+        console.warn(
+          'WARNING: You are caching visitor data for longer than 24 hours. This will negatively affect identification accuracy. ' +
+            'To ensure high identification accuracy, we recommend not to cache visitors data for longer than 24 hours.'
+        )
+      } else {
+        throw new Error(`Cache time cannot exceed 86400 seconds (24 hours)`)
+      }
     }
 
     const cacheTime = options?.cacheTimeInSeconds ?? DEFAULT_CACHE_LIFE

--- a/src/global.ts
+++ b/src/global.ts
@@ -43,4 +43,10 @@ export interface FpjsClientOptions {
    * Custom prefix for localStorage and sessionStorage cache keys. Will be ignored if `cache` is provided.
    */
   cachePrefix?: string
+
+  /**
+   * If set to true, allows cacheTimeInSeconds to exceed 86_400 (24h). A warning will be logged instead of throwing an error.
+   * WARNING: Caching data for longer than 24 hours will negatively affect identification accuracy and is strongly discouraged.
+   */
+  __dangerouslyDisableCacheTimeLimitAndAcceptLowAccuracy?: boolean
 }


### PR DESCRIPTION
Introduced a new option `__dangerouslyDisableCacheTimeLimitAndAcceptLowAccuracy` in `FpjsClient` to allow cache time to exceed 24 hours.

Fixes [#107](https://github.com/fingerprintjs/fingerprintjs-pro-spa/issues/107)